### PR TITLE
fix(autocomplete): Fix unused defaultValue prop

### DIFF
--- a/packages/autocomplete/src/component/Autocomplete.jsx
+++ b/packages/autocomplete/src/component/Autocomplete.jsx
@@ -220,6 +220,7 @@ class Autocomplete extends Component<Props, IState> {
              onFocus={() => this.openPane()}
              placeholder={this.props.placeholder || ''}
              required={!!this.props.required}
+             defaultValue={this.state.defaultValue}
       />
     );
   }


### PR DESCRIPTION
The defaultValue prop was not being used, which resulted in it not
working.

Closes #244

## PR Checklist

This PR fulfills the following requirements:
<!-- Please put "[x]" for requirements that this PR satisfies. -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A changelog entry has been added to CHANGELOG.md if necessary

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] react application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
defaultValue prop on the Autocomplete component does nothing.

Issue Number: #244 

## What is the new behavior?
defaultValue prop on the Autocomplete component iis taken into account.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## Resolved issues
Fixes: #244 