### PR TITLE
:sparkles: Added support for custom confirm and deny elements

### DIFF
--- a/packages/modal/src/Modal.js
+++ b/packages/modal/src/Modal.js
@@ -202,6 +202,10 @@ export default class Modal extends React.Component<Props, State> {
 
     const sizeClass = sizes[size];
 
+    const showConfirm = confirmElm || confirmText;
+    const showDeny = denyElm || denyText;
+    const showFooter = showConfirm || showDeny;
+
     return (
       <div>
         {modalTrigger}
@@ -238,10 +242,10 @@ export default class Modal extends React.Component<Props, State> {
                 {children}
               </div>
             )}
-            {(confirmText || denyText || confirmElm || denyElm) && (
+            {showFooter && (
               <div className="m-modal__footer">
-                {confirmTrigger}
-                {denyTrigger}
+                {showConfirm && confirmTrigger}
+                {showDeny && denyTrigger}
               </div>
             )}
           </div>

--- a/packages/modal/src/Modal.js
+++ b/packages/modal/src/Modal.js
@@ -20,8 +20,12 @@ type Props = {
   hasCloseButton?: boolean,
   /** Modal title text. */
   title?: string,
+  /** Custom confirm element (will close modal on click and trigger onConfirm). */
+  confirmElm?: React.Node,
   /** Confirm button text. */
   confirmText?: string,
+  /** Custom deny element (will close modal on click and trigger onDeny). */
+  denyElm?: React.Node,
   /** Deny button text. */
   denyText?: string,
   /** Custom trigger element (will trigger on click). */
@@ -73,7 +77,9 @@ export default class Modal extends React.Component<Props, State> {
     hasCloseButton: true,
     title: '',
 
+    confirmElm: null,
     confirmText: 'Ja',
+    denyElm: null,
     denyText: 'Nee',
     triggerElm: null,
     triggerText: 'Open',
@@ -164,7 +170,9 @@ export default class Modal extends React.Component<Props, State> {
       onRequestClose,
       title,
       hasCloseButton,
+      confirmElm,
       confirmText,
+      denyElm,
       denyText,
       className,
       overlayClassName,
@@ -183,6 +191,14 @@ export default class Modal extends React.Component<Props, State> {
     const modalTrigger = triggerElm ? this.addProps(triggerElm, {
       onClick: () => this.handleToggleModal(true),
     }) : <Button type="primary" onClick={() => this.handleToggleModal(true)}>{triggerText}</Button>;
+
+    const confirmTrigger = confirmElm ? this.addProps(confirmElm, {
+      onClick: this.handleConfirm,
+    }) : <Button className="m-modal__confirm" onClick={this.handleConfirm}>{confirmText}</Button>;
+
+    const denyTrigger = denyElm ? this.addProps(denyElm, {
+      onClick: this.handleDeny,
+    }) : <Button className="m-modal__deny" outline onClick={this.handleDeny}>{denyText}</Button>
 
     const sizeClass = sizes[size];
 
@@ -222,14 +238,10 @@ export default class Modal extends React.Component<Props, State> {
                 {children}
               </div>
             )}
-            {(confirmText || denyText) && (
+            {(confirmText || denyText || confirmElm || denyElm) && (
               <div className="m-modal__footer">
-                {confirmText && (
-                  <Button className="m-modal__confirm" onClick={this.handleConfirm}>{confirmText}</Button>
-                )}
-                {denyText && (
-                  <Button className="m-modal__deny" outline onClick={this.handleDeny}>{denyText}</Button>
-                )}
+                {confirmTrigger}
+                {denyTrigger}
               </div>
             )}
           </div>


### PR DESCRIPTION
wha## PR Checklist

This PR fulfills the following requirements:
<!-- Please put "[x]" for requirements that this PR satisfies. -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A changelog entry has been added to CHANGELOG.md if necessary

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] react application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
It adds the possibility to overwrite the buttons used for confirming or denying the modal. 
This way it's possible to add things like disabling the button for usecases like form validation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## Resolved issues

<!--
See https://help.github.com/articles/closing-issues-using-keywords/ for more info
Closes: #123
Fixes: #123
Resolves: #123
-->